### PR TITLE
'Illegal character in path' using addRepoProperties on Windows

### DIFF
--- a/com.codeaffine.gonsole.releng/repository/pom.xml
+++ b/com.codeaffine.gonsole.releng/repository/pom.xml
@@ -168,7 +168,7 @@
             <configuration>
               <appArgLine>-application org.eclipse.wtp.releng.tools.addRepoProperties</appArgLine>
               <argLine>
-                -DartifactRepoDirectory=${project.build.directory}/repository
+                -DartifactRepoDirectory=${project.baseUri}/target/repository
                 -Dp2StatsURI=http://codeaffine.com/p2-stats
                 -DstatsTrackedArtifacts=com.codeaffine.gonsole.feature
                 -DstatsArtifactsSuffix=-${project.version}


### PR DESCRIPTION
This patch uses ${project.baseUri} instead to create a path that is
cross platform compatible.

Bug 436244 (https://bugs.eclipse.org/436244)
Signed-off-by: Thanh Ha thanh.ha@eclipse.org
