### PR TITLE
Export internal packages as X-internal

### DIFF
--- a/com.codeaffine.console.core/META-INF/MANIFEST.MF
+++ b/com.codeaffine.console.core/META-INF/MANIFEST.MF
@@ -16,4 +16,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",
  org.eclipse.ui.workbench.texteditor;bundle-version="[3.7.0,4.0.0)"
 Export-Package: com.codeaffine.console.core;version="1.2.0.qualifier",
  com.codeaffine.console.core.history;version="1.2.0.qualifier",
+ com.codeaffine.console.core.internal;version="1.2.0.qualifier";x-internal:=true,
+ com.codeaffine.console.core.internal.contentassist;version="1.2.0.qualifier";x-internal:=true,
+ com.codeaffine.console.core.internal.resource;version="1.2.0.qualifier";x-internal:=true,
  com.codeaffine.console.core.util;version="1.2.0.qualifier"


### PR DESCRIPTION
I'd like to access `GenericConsole` from another plugin, i.e. I'm embedding a console in my own view. Thus, it would be good if the internal packages were exported somehow.

As an alternative, I could imaging exposing `GenericConsole` as API (like `IOConsole` is). Would you consider that?